### PR TITLE
Revert "Bump python from 3.10.1-slim to 3.11.0a4-slim"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11.0a4-slim
+FROM python:3.10.1-slim
 
 ARG APP_VERSION
 ENV APP_VERSION=$APP_VERSION


### PR DESCRIPTION
Reverts apmaros/dataengine#21